### PR TITLE
Fix errors which were stopping to reproduce the results

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The code requires:
 Dependencies can be installed via the following command:
 
 ```setup
-pip -r install requirements.txt
+pip install -r requirements.txt
 ```
 
 
@@ -42,14 +42,11 @@ Finding midpoints for identifying a quadratic path between VGG-13 models on CIFA
 python train_eval_mc.py --model=VGG-13 --perform=train_midpoint --cue_type=box --id_data=cue --base_dataset=CIFAR10 --cue_proportion=0.8
 ```
 
-
 Mechanistic fine-tuning using CBFT of a VGG-13 model trained on CIFAR-10 with box cues dataset that contained 80% samples with synthetic cues.
 
 ```mechft
-python mech_fine_tuning.py --model=VGG-13 --base_dataset=CIFAR-10 --cue_model_path=path_to_model --cue_type=box --cue_proportion=0.8 --n_epochs=20 --ft_method=CBFT --n_clean=2500 --n_cue=47500
+python mech_fine_tuning.py --model=VGG-13 --base_dataset=CIFAR10 --cue_model_path=path_to_model --cue_type=box --cue_proportion=0.8 --n_epochs=20 --ft_method=CBFT --n_clean=2500 --n_cue=47500
 ```
-
-
 
 ## Organization
 
@@ -68,4 +65,3 @@ python mech_fine_tuning.py --model=VGG-13 --base_dataset=CIFAR-10 --cue_model_pa
 * **models.py**: Model definitions (VGG-13 / ResNet-18)
 
 * **utils.py**: Test evaluation function / Learning rate scheduler
-

--- a/mech_fine_tuning.py
+++ b/mech_fine_tuning.py
@@ -8,8 +8,10 @@ import torch.backends.cudnn as cudnn
 import torch.nn.functional as F
 import numpy as np
 import copy
+import os
 
 import syndata
+import utils
 from models import create_model
 from utils import linear_eval, LR_Scheduler
 
@@ -163,8 +165,8 @@ def CBFT(dataloader_cue, dataloader_nocue, epoch=0, lambd=1, warmup_epochs=1, lo
             # compute loss
             net_nc.zero_grad()
             if(epoch < warmup_epochs):
-                outputs_ns = net_ns(inputs_ns)
-                loss = criterion(outputs_ns, targets_ns)
+                outputs_nc = net_nc(inputs_nc)
+                loss = criterion(outputs_nc, targets_nc)
             else:
                 z_nc, z_c = net_nc(inputs_nc, use_linear=False), net_nc(inputs_c, use_linear=False)
                 inv_loss = 0
@@ -281,6 +283,11 @@ if __name__ == "__main__":
     accs_dict = {'train_cue': [], 'train_nocue': [], 'test_cue': [], 'test_nocue': [], 'test_randcue': [], 'test_randimg': []}
 
 
+    # Ensure the directory exists before trying to open a file in it
+    dir_name = "./tab_results/"
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name)
+    
     ##### LLRT / LPFT: do LLRT separately for ease of implementation
     if(args.ft_method == 'LLRT' or args.ft_method == 'LPFT'):
         LLRT(dataloader=dataloader_nocue, n_epochs=200, base_lr=30)
@@ -336,4 +343,3 @@ if __name__ == "__main__":
                     }
     with open("./tab_results/{}_{}_{}_{}_proportion_{}_seed_{}.pkl".format(args.start_lr, args.model, args.ft_method, args.base_dataset, args.save_proportion, args.seed), 'wb') as f:
         pkl.dump(saved_results, f)
-        

--- a/syndata.py
+++ b/syndata.py
@@ -175,7 +175,7 @@ def get_dataloader(load_type='train', base_dataset='CIFAR10', cue_type='nocue', 
     # define base dataset (pick train or test)
     dset_type = getattr(torchvision.datasets, base_dataset)
     dset = dset_type(root=f'{data_dir}/{base_dataset.lower()}/', 
-                     train=(load_type == 'train'), download=False, transform=get_transform('nocue'))
+                     train=(load_type == 'train'), download=True, transform=get_transform('nocue'))
 
     # pick cue
     if (cue_type == 'nocue'):
@@ -218,6 +218,3 @@ def get_dominoes_associations(targets_fmnist, targets_c10):
         idx_fmnist = np.where(targets_fmnist == class_num)[0]
         association_ids[class_num] = {idx_c10[i]: idx_fmnist[i] for i in range(len(targets_c10) // 10)}
     return association_ids
-
-
-

--- a/train_eval_mc.py
+++ b/train_eval_mc.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
     save_path = args.save_path
     if(args.path_cue == None):
-        path_cue = './saved_models/{}_{}_net_100_epochs_{}_cue_{:.1f}_proportion_1.0_not_pretrained_{}_seed.pth'.format(
+        path_cue = './saved_models/cue/{}_{}_net_100_epochs_{}_cue_{:.1f}_proportion_not_pretrained_{}_seed.pth'.format(
             args.base_dataset, args.model, args.cue_type, args.cue_proportion, args.seed)
     else:
         path_cue = args.path_cue

--- a/trainer.py
+++ b/trainer.py
@@ -58,6 +58,11 @@ def net_train(net, optimizer, epoch, dataloader, lr_val=0.1):
 
 ### Main
 if __name__ == "__main__":
+    accs_dict = {
+        'train': [],
+        'test_nocue': [],
+        'test_cue': []
+    }
 
     # setup
     parser = argparse.ArgumentParser()
@@ -67,6 +72,8 @@ if __name__ == "__main__":
     parser.add_argument("--base_dataset", default='CIFAR10', choices=['CIFAR10', 'CIFAR100', 'Dominoes'])
     parser.add_argument("--cue_type", default='nocue', choices=['nocue', 'box', 'dominoes'])
     parser.add_argument("--cue_proportion", type=float, default=1.)
+    parser.add_argument("--nocue_type", default='box', choices=['nocue', 'box', 'dominoes'])
+    parser.add_argument("--nocue_proportion", type=float, default=0.8)
     parser.add_argument("--n_epochs", type=int, default=100)
     parser.add_argument("--batch_size", type=int, default=256)
     parser.add_argument("--start_lr", type=float, default=0.1)


### PR DESCRIPTION
This PR fixes few issues:
- Fix typos in README
- Set the download argument to True which allows users to download data after running the command `download=True`
`File: syndata.py`
- define `accs_dict` as an empty dictionary because it has not been defined before it is being used in our code. `File: trainer.py`
```python
accs_dict = {
        'train': [],
        'test_nocue': [],
        'test_cue': []
    }
```
- Correct the model path